### PR TITLE
Remove limitations for Fusion

### DIFF
--- a/src/main/java/org/embeddedt/vintagefix/core/MixinConfigPlugin.java
+++ b/src/main/java/org/embeddedt/vintagefix/core/MixinConfigPlugin.java
@@ -170,7 +170,7 @@ public class MixinConfigPlugin implements IMixinConfigPlugin {
     public static boolean isMixinClassApplied(String name) {
         String baseName = mixinClassNameToBaseName(name);
         // texture optimization causes issues when OF is installed
-        if(baseName.startsWith("mixin.textures") && (VintageFixCore.OPTIFINE || VintageFixCore.FUSION)) {
+        if(baseName.startsWith("mixin.textures") && VintageFixCore.OPTIFINE) {
             return false;
         }
         boolean isEnabled = Boolean.parseBoolean(config.getProperty(baseName, ""));

--- a/src/main/java/org/embeddedt/vintagefix/core/VintageFixCore.java
+++ b/src/main/java/org/embeddedt/vintagefix/core/VintageFixCore.java
@@ -18,7 +18,6 @@ import java.util.Map;
 @IFMLLoadingPlugin.MCVersion("1.12.2")
 public class VintageFixCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
     public static boolean OPTIFINE;
-    public static boolean FUSION;
 
     public VintageFixCore() {
         try {
@@ -71,7 +70,6 @@ public class VintageFixCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     private static void applyMixinFix() {
         OPTIFINE = classExists("ofdev.launchwrapper.OptifineDevTweakerWrapper") || classExists("optifine.OptiFineForgeTweaker");
-        FUSION = classExists("com.supermartijn642.fusion.core.CoreMod");
         /* https://github.com/FabricMC/Mixin/pull/99 */
         try {
             Field groupMembersField = InjectorGroupInfo.class.getDeclaredField("members");


### PR DESCRIPTION
When Fusion is installed, the optimizations for texture loading were disabled to avoid conflicts. I have now added separate mixins for when VintageFix is detected in Fusion, thus the optimizations can now once again be enabled.
This PR simply removes any checks for Fusion.