### PR TITLE
Fix "squashBakedQuads" not being disabled with BlahajASM

### DIFF
--- a/src/main/java/org/embeddedt/vintagefix/core/VintageFixCore.java
+++ b/src/main/java/org/embeddedt/vintagefix/core/VintageFixCore.java
@@ -27,7 +27,7 @@ public class VintageFixCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     public VintageFixCore() {
         // Force-disable squashBakedQuads in any known *ASM mods
-        for (String clz : new String[] { "zone.rong.loliasm.core.LoliTransformer", "mirror.normalasm.core.NormalTransformer" }) {
+        for (String clz : new String[] { "zone.rong.loliasm.core.LoliTransformer", "mirror.normalasm.core.NormalTransformer", "mirror.blahajasm.core.BlahajTransformer" }) {
             try {
                 Class<?> transformerClass = Class.forName(clz);
                 Field field = transformerClass.getDeclaredField("squashBakedQuads");


### PR DESCRIPTION
BlahajASM's package isnt called NormalASM and there for breaks with VintageFix