### PR TITLE
Avoid client chunk map shrinking

### DIFF
--- a/src/main/java/org/embeddedt/vintagefix/mixin/chunk_access/ChunkProviderClientMixin.java
+++ b/src/main/java/org/embeddedt/vintagefix/mixin/chunk_access/ChunkProviderClientMixin.java
@@ -10,5 +10,13 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(ChunkProviderClient.class)
 public class ChunkProviderClientMixin {
-    @Shadow @Final private final Long2ObjectMap<Chunk> loadedChunks = new VintageChunkMap();
+    @Shadow @Final private final Long2ObjectMap<Chunk> loadedChunks = new VintageChunkMap() {
+        @Override
+        protected void rehash(int newN) {
+            // avoid shrinking
+            if (newN > this.key.length) {
+                super.rehash(newN);
+            }
+        }
+    };
 }


### PR DESCRIPTION
This PR overrides the `rehash` method in `ChunkProviderClientMixin` to avoid shrinking. Vanilla does the same in `ChunkProviderClient`.
Additionally this fixes a crash with EntityCulling which can happen when accessing the client world from another thread (https://github.com/Meldexun/EntityCulling/issues/89).