### PR TITLE
Fixes NAE2 block model overrides not being applied during dynamic model baking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,8 @@ dependencies {
   compileOnly(rfg.deobf("curse.maven:extrautils-225561:2678374"))
   compileOnly(rfg.deobf("curse.maven:chiselsandbits-231095:2720655"))
   compileOnly(rfg.deobf("curse.maven:projectredexpansion-229048:2745550"))
+  compileOnly(rfg.deobf("curse.maven:nae2-884359:5380800"))
+
   shadow("com.esotericsoftware:kryo:5.1.1")
   val mixinExtras = "io.github.llamalad7:mixinextras-common:0.3.6"
   shadow(mixinExtras)

--- a/src/main/java/org/embeddedt/vintagefix/mixin/dynamic_resources/NAE2AutoRotatingModelMixin.java
+++ b/src/main/java/org/embeddedt/vintagefix/mixin/dynamic_resources/NAE2AutoRotatingModelMixin.java
@@ -1,0 +1,40 @@
+package org.embeddedt.vintagefix.mixin.dynamic_resources;
+
+
+import co.neeve.nae2.common.registration.registry.components.NAEModelOverrideComponent;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.embeddedt.vintagefix.annotation.ClientOnlyMixin;
+import org.embeddedt.vintagefix.annotation.LateMixin;
+import org.embeddedt.vintagefix.event.DynamicModelBakeEvent;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+@Mixin(NAEModelOverrideComponent.class)
+@LateMixin
+@ClientOnlyMixin
+public class NAE2AutoRotatingModelMixin {
+
+    @Shadow(remap = false)
+    @Final
+    private Map<String, BiFunction<ModelResourceLocation, IBakedModel, IBakedModel>> customizer;
+
+    @SubscribeEvent
+    public void onDynamicModelBake(DynamicModelBakeEvent e) {
+        if (e.location instanceof ModelResourceLocation && e.location.getNamespace().equals("nae2")) {
+            IBakedModel orgModel = e.bakedModel;
+            BiFunction<ModelResourceLocation, IBakedModel, IBakedModel> customizer = this.customizer.get(e.location.getPath());
+            if (customizer != null) {
+                IBakedModel newModel = customizer.apply((ModelResourceLocation) e.location, orgModel);
+                if (newModel != orgModel) {
+                    e.bakedModel = newModel;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ensures that NAE2-registered model customizers are correctly invoked for dynamically baked models, restoring expected rendering for affected blocks